### PR TITLE
Fix broken tests until 1.5 is released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ python:
   - "2.7"
 script: nosetests
 env:
-  - DJANGO_VERSION=1.4.3
-  - DJANGO_VERSION=1.5
+  - DJANGO_VERSION="Django==1.4.3"
+  - DJANGO_VERSION=https://www.djangoproject.com/download/1.5c1/tarball/
 install:
 #  - pip install pep8 --use-mirrors
-  - pip install -q Django==$DJANGO_VERSION
+  - pip install -q $DJANGO_VERSION
   - python setup.py -q install
   - pip install -r requirements.txt --use-mirrors
 


### PR DESCRIPTION
All the Travis badges say the build is failing. The reason is that 1.5 hasn't been released yet. I just did the GitHub edit thing, so I haven't tested this, but I'm guessing it will fix the build process at Travis

It can be reverted when 1.5 is released.
