### PR TITLE
xls export (api only) & cvs export - adding options and fixing filename kwarg

### DIFF
--- a/adminactions/api.py
+++ b/adminactions/api.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.db.models.fields.related import ManyToManyField, OneToOneField
 from django.http import HttpResponse
 from adminactions.templatetags.actions import get_field_value
+import xlwt
 try:
     import unicodecsv as csv
 except ImportError:
@@ -110,7 +111,8 @@ def merge(master, other, fields=None, commit=False, m2m=None, related=None):
     return result
 
 
-def export_as_csv(queryset, fields=None, header=False, filename=None, options=None, out=None):
+def export_as_csv(queryset, fields=None, header=False, filename=None, options=None, out=None, header_alt=None,
+                  dialect=None):
     """
         Exports a queryset as csv from a queryset with the given fields.
 
@@ -119,12 +121,13 @@ def export_as_csv(queryset, fields=None, header=False, filename=None, options=No
     :param header: if True, the exported file will have the first row as column names
     :param filename: name of the filename
     :param options: CSVOptions() instance or none
-    :param: out: object that implements File protocol. HttpResponse if None.
-
-    :return: HttpResponse instance
+    :param out: object that implements File protocol. HttpResponse if None.
+    :param header_alt: if is not None, and header is True, the first row will be as header_alt (same nr columns)
+    :param dialect: if is not None, will use this instead of options for csv writer, (see dialects in unicodecsv)
+    :return: HttpResponse instance if out not supplied, otherwise out
     """
-    filename = filename or "%s.csv" % queryset.model._meta.verbose_name_plural.lower().replace(" ", "_")
     if out is None:
+        filename = filename or "%s.csv" % queryset.model._meta.verbose_name_plural.lower().replace(" ", "_")
         response = HttpResponse(mimetype='text/csv')
         response['Content-Disposition'] = 'attachment;filename="%s"' % filename.encode('us-ascii', 'replace')
     else:
@@ -139,13 +142,20 @@ def export_as_csv(queryset, fields=None, header=False, filename=None, options=No
     if fields is None:
         fields = [f.name for f in queryset.model._meta.fields]
 
-    writer = csv.writer(response,
-                        escapechar=str(config['escapechar']),
-                        delimiter=str(config['delimiter']),
-                        quotechar=str(config['quotechar']),
-                        quoting=int(config['quoting']))
+    if dialect is not None:
+        writer = csv.writer(response, dialect=dialect)
+    else:
+        writer = csv.writer(response,
+                            escapechar=str(config['escapechar']),
+                            delimiter=str(config['delimiter']),
+                            quotechar=str(config['quotechar']),
+                            quoting=int(config['quoting']))
+
     if header:
-        writer.writerow([f for f in fields])
+        if header_alt is not None:
+            writer.writerow([f for f in header_alt])
+        else:
+            writer.writerow([f for f in fields])
     for obj in queryset:
         row = []
         for fieldname in fields:
@@ -159,4 +169,66 @@ def export_as_csv(queryset, fields=None, header=False, filename=None, options=No
             row.append(smart_str(value))
         writer.writerow(row)
 
+    return response
+
+
+formatting_default = {'date_format': 'd/m/Y',
+                      'datetime_format': 'N j, Y, P',
+                      'time_format': 'P', }
+
+
+def export_as_xls(queryset, sheet_name=None, fields=None, header=False, header_alt=None, filename=None,
+                  formatting=None, out=None):
+    """
+    Exports a queryset as xls from a queryset with the given fields.
+
+    :param queryset: queryset to export (can also be list of namedtuples)
+    :param fields: list of fields names to export. None for all fields
+    :param header: if True, the exported file will have the first row as column names
+    :param out: object that implements File protocol.
+    :param header_alt: if is not None, and header is True, the first row will be as header_alt (same nr columns)
+    :param formatting: if is None will use formatting_default
+    :return: HttpResponse instance if out not supplied, otherwise out
+    """
+    if out is None:
+        filename = filename or "%s.csv" % queryset.model._meta.verbose_name_plural.lower().replace(" ", "_")
+        response = HttpResponse(mimetype='text/csv')
+        response['Content-Disposition'] = 'attachment;filename="%s"' % filename.encode('us-ascii', 'replace')
+    else:
+        response = out
+    book = xlwt.Workbook(encoding="UTF-8")
+    if sheet_name is None:
+        sheet_name = 'Sheet1'
+    sheet = book.add_sheet(sheet_name)
+    if fields is None:
+        fields = [f.name for f in queryset.model._meta.fields]
+
+    if formatting is None:
+        formatting = formatting_default
+
+    if header_alt:
+        header_row = header_alt
+    else:
+        header_row = fields
+
+    def write_row(row_nr, row):
+        for col_nr, cell_value in enumerate(row):
+            sheet.write(row_nr, col_nr, cell_value)
+
+    if header:
+        write_row(0, header_row)
+
+    for row_nr, obj in enumerate(queryset):
+        row = []
+        for fieldname in fields:
+            value = get_field_value(obj, fieldname)
+            if isinstance(value, datetime.datetime):
+                value = dateformat.format(value, formatting['datetime_format'])
+            elif isinstance(value, datetime.date):
+                value = dateformat.format(value, formatting['date_format'])
+            elif isinstance(value, datetime.time):
+                value = dateformat.format(value, formatting['time_format'])
+            row.append(smart_str(value))
+        write_row(row_nr + 1, row)
+    book.save(response)
     return response

--- a/adminactions/requirements.pip
+++ b/adminactions/requirements.pip
@@ -1,3 +1,5 @@
 unicodecsv>=0.9.0
 mock
 selenium
+xlrd==0.9.2
+xlwt==0.7.5

--- a/adminactions/tests/__init__.py
+++ b/adminactions/tests/__init__.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from .mass_update import *  # NOQA
 from .exports import *  # NOQA
 from .merge import MergeTest, MergeTestApi  # NOQA
+from .export_api import * # NOQA
 
 if getattr(settings, 'ENABLE_SELENIUM', True):
     try:

--- a/adminactions/tests/export_api.py
+++ b/adminactions/tests/export_api.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+import unittest
+import xlrd
+from adminactions.api import export_as_csv, export_as_xls
+import StringIO
+from collections import namedtuple
+
+
+class ExportAsCsv(unittest.TestCase):
+
+    def test_export_as_csv(self):
+        fields = ['field1', 'field2']
+        header = ['Field 1', 'Field 2']
+        Row = namedtuple('Row', fields)
+        rows = [Row(1, 4),
+                Row(2, 5),
+                Row(3, u'ӼӳӬԖԊ')]
+        mem = StringIO.StringIO()
+        export_as_csv(queryset=rows, fields=fields, header=True, header_alt=header, dialect='excel', out=mem)
+        mem.seek(0)
+        csv_dump = mem.read()
+        self.assertEquals(csv_dump.decode('utf8'), u'Field 1,Field 2\r\n1,4\r\n2,5\r\n3,ӼӳӬԖԊ\r\n')
+
+
+class ExportAsExcel(unittest.TestCase):
+
+    def test_export_as_xls(self):
+        fields = ['field1', 'field2']
+        header = ['Field 1', 'Field 2']
+        Row = namedtuple('Row', fields)
+        rows = [Row(1, 4),
+                Row(2, 5),
+                Row(3, u'ӼӳӬԖԊ')]
+        mem = StringIO.StringIO()
+        export_as_xls(queryset=rows, fields=fields, header=True, header_alt=header, out=mem)
+        mem.seek(0)
+        xls_workbook = xlrd.open_workbook(file_contents=mem.read())
+        xls_sheet = xls_workbook.sheet_by_index(0)
+        self.assertEqual(xls_sheet.row_values(0)[:], ['Field 1', 'Field 2'])
+        self.assertEqual(xls_sheet.row_values(1)[:], ['1', '4'])
+        self.assertEqual(xls_sheet.row_values(2)[:], ['2', '5'])
+        self.assertEqual(xls_sheet.row_values(3)[:], ['3', u'ӼӳӬԖԊ'])


### PR DESCRIPTION
xls export: only as an api method (similar to export_as_csv)

csv export: filename kwarg was required even when using out kwarg

added options: dialect. alternative header. 
