### PR TITLE
xlwt is an install requirements

### DIFF
--- a/adminactions/requirements/install.pip
+++ b/adminactions/requirements/install.pip
@@ -1,1 +1,2 @@
 unicodecsv>=0.9.4
+xlwt>=0.7.5


### PR DESCRIPTION
as it's imported in the api.py module.
