### PR TITLE
fix mass_update bug that caused all records in a table to be updated whe...

### DIFF
--- a/adminactions/templates/adminactions/mass_update.html
+++ b/adminactions/templates/adminactions/mass_update.html
@@ -40,7 +40,7 @@
     {% endif %}
     {{ form.non_field_errors }}
     <div id='col1'>
-        <form action="." method="post">
+        <form action="" method="post">
             {% csrf_token %}
             <table border="1">
                 {% for field in adminform.form.configured_fields %}
@@ -87,7 +87,7 @@
                 {{ hidden }}
             {% endfor %}
 {#            <input type="hidden" name="action" value="{{ action }}"/>#}
-            <input type="submit" name="apply" value="Update records"/>
+            <input type="submit" name="apply" value="Update {{ selection.count }} records"/>
         </form>
     </div>
 {#    <div id='col2'>#}


### PR DESCRIPTION
Fix a serious bug in mass_update that causes every row in a table to be updated when selecting over one page of records to update.  Using form action="." in the mass_update form causes the search and filter criteria not to be sent when the submit button is clicked, resulting in all rows being updated.
