### PR TITLE
added option for activating get_field_display when exporting into xls

### DIFF
--- a/adminactions/api.py
+++ b/adminactions/api.py
@@ -245,6 +245,7 @@ def export_as_xls(queryset, fields=None, header=None, filename=None, options=Non
 
     book = xlwt.Workbook(encoding="UTF-8", style_compression=2)
     sheet_name = config.pop('sheet_name')
+    use_display = config.get('use_display', False)
 
     sheet = book.add_sheet(sheet_name)
     style = xlwt.XFStyle()
@@ -271,7 +272,7 @@ def export_as_xls(queryset, fields=None, header=None, filename=None, options=Non
             try:
                 value = get_field_value(row,
                                         fieldname,
-                                        usedisplay=False,
+                                        usedisplay=use_display,
                                         raw_callable=False)
                 if callable(fmt):
                     value = xlwt.Formula(fmt(value))

--- a/adminactions/forms.py
+++ b/adminactions/forms.py
@@ -52,6 +52,7 @@ class XLSOptions(forms.Form):
     action = forms.CharField(label='', required=True, initial='', widget=forms.HiddenInput())
 
     header = forms.BooleanField(required=False)
+    use_display = forms.BooleanField(required=False)
     # delimiter = forms.ChoiceField(choices=zip(delimiters, delimiters), initial=',')
     # quotechar = forms.ChoiceField(choices=zip(quotes, quotes), initial="'")
     # quoting = forms.ChoiceField(

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -258,3 +258,56 @@ class ExportAsXlsTest(ExportMixin, SelectRowsMixin, CheckSignalsMixin, WebTest):
             self.assertEquals(sheet.cell_value(1, 2), u'sax')
             self.assertEquals(sheet.cell_value(2, 2), u'user')
             # self.assertEquals(sheet.cell_value(3, 2), u'user_00')
+
+    def test_use_display_ok(self):
+        with user_grant_permission(self.user, ['tests.change_demomodel', 'tests.adminactions_export_demomodel']):
+            res = self.app.get('/', user='user')
+            res = res.click('Demo models')
+            form = res.forms['changelist-form']
+            form['action'] = self.action_name
+            self._select_rows(form)
+            res = form.submit()
+            res.form['header'] = 1
+            res.form['use_display'] = 1
+            res.form['columns'] = ['char', 'text', 'bigint', 'choices'
+                                                             '']
+            res = res.form.submit('apply')
+            io = StringIO.StringIO(res.body)
+
+            io.seek(0)
+            w = xlrd.open_workbook(file_contents=io.read())
+            sheet = w.sheet_by_index(0)
+            self.assertEquals(sheet.cell_value(0, 1), u'char')
+            self.assertEquals(sheet.cell_value(0, 2), u'bigint')
+            self.assertEquals(sheet.cell_value(0, 3), u'text')
+            self.assertEquals(sheet.cell_value(0, 4), u'choices')
+            self.assertEquals(sheet.cell_value(1, 1), u'ccccc')
+            self.assertEquals(sheet.cell_value(1, 2), 333333333.0)
+            self.assertEquals(sheet.cell_value(1, 3), u'lorem ipsum')
+            self.assertEquals(sheet.cell_value(1, 4), u'Choice 2')
+
+    def test_use_display_ko(self):
+        with user_grant_permission(self.user, ['tests.change_demomodel', 'tests.adminactions_export_demomodel']):
+            res = self.app.get('/', user='user')
+            res = res.click('Demo models')
+            form = res.forms['changelist-form']
+            form['action'] = self.action_name
+            self._select_rows(form)
+            res = form.submit()
+            res.form['header'] = 1
+            res.form['columns'] = ['char', 'text', 'bigint', 'choices'
+                                                             '']
+            res = res.form.submit('apply')
+            io = StringIO.StringIO(res.body)
+
+            io.seek(0)
+            w = xlrd.open_workbook(file_contents=io.read())
+            sheet = w.sheet_by_index(0)
+            self.assertEquals(sheet.cell_value(0, 1), u'char')
+            self.assertEquals(sheet.cell_value(0, 2), u'bigint')
+            self.assertEquals(sheet.cell_value(0, 3), u'text')
+            self.assertEquals(sheet.cell_value(0, 4), u'choices')
+            self.assertEquals(sheet.cell_value(1, 1), u'ccccc')
+            self.assertEquals(sheet.cell_value(1, 2), 333333333.0)
+            self.assertEquals(sheet.cell_value(1, 3), u'lorem ipsum')
+            self.assertEquals(sheet.cell_value(1, 4), 2.0)


### PR DESCRIPTION
added a checkbox into the export xls form for giving to the user the chance to activate or not the translation of models choicefields (get_field_display) (instead of filling the cell into the excel with the raw data)
