### PR TITLE
feat(api): allow streaming export to CSV response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Release 0.8.5.1
+===============
+* support settings.ADMINACTIONS_CSV_OPTIONS_DEFAULT
+* support streaming CSV file response
+
 Release 0.8.5
 =============
 * repackage due broken version in 0.8.4

--- a/adminactions/__init__.py
+++ b/adminactions/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 NAME = 'django-adminactions'
-VERSION = __version__ = (0, 8, 5, 'final', 0)
+VERSION = __version__ = (0, 8, 5, 'final', 1)
 __author__ = 'sax'
 
 import subprocess
@@ -27,6 +27,8 @@ def get_version(version=None):
     elif version[3] != 'final':
         mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
         sub = mapping[version[3]] + str(version[4])
+    elif version[3] == 'final' and version[4] != 0:
+        sub = '-%s' % version[4]
 
     return main + sub
 


### PR DESCRIPTION
The idea is taken from [django docs on outputting large CSV files](https://docs.djangoproject.com/en/1.8/howto/outputting-csv/#streaming-csv-files)

* includes test and documentation
* Stream using HttpResponse for Django <= 1.5.
  Even though Django 1.5 supports StreamingHttpResponse,
  [ticket #20331](https://code.djangoproject.com/ticket/20331)
  prevents admin actions from using it, and the fix django/django@b75a3b0df91579723737403823353861de2ba208 was
  included only since Django 1.6