### PR TITLE
fix(api): reuse xls style while iterating over cells

### DIFF
--- a/adminactions/api.py
+++ b/adminactions/api.py
@@ -268,6 +268,8 @@ def export_as_xls2(queryset, fields=None, header=None,  # noqa
 
     settingstime_zone = pytz.timezone(settings.TIME_ZONE)
 
+    _styles = {}
+
     for rownum, row in enumerate(queryset):
         sheet.write(rownum + 1, 0, rownum + 1)
         for idx, fieldname in enumerate(fields):
@@ -277,11 +279,12 @@ def export_as_xls2(queryset, fields=None, header=None,  # noqa
                                         fieldname,
                                         usedisplay=use_display,
                                         raw_callable=False)
-                if callable(fmt):
-                    value = xlwt.Formula(fmt(value))
-                    style = xlwt.easyxf(num_format_str='formula')
-                else:
-                    style = xlwt.easyxf(num_format_str=fmt)
+                if hash(fmt) not in _styles:
+                    if callable(fmt):
+                        value = xlwt.Formula(fmt(value))
+                        _styles[hash(fmt)] = xlwt.easyxf(num_format_str='formula')
+                    else:
+                        _styles[hash(fmt)] = xlwt.easyxf(num_format_str=fmt)
 
                 if isinstance(value, datetime.datetime):
                     try:
@@ -292,10 +295,10 @@ def export_as_xls2(queryset, fields=None, header=None,  # noqa
                 if isinstance(value, (list, tuple)):
                     value = "".join(value)
 
-                sheet.write(rownum + 1, idx + 1, value, style)
+                sheet.write(rownum + 1, idx + 1, value, _styles[hash(fmt)])
             except Exception as e:
                 # logger.warning("TODO refine this exception: %s" % e)
-                sheet.write(rownum + 1, idx + 1, smart_str(e), style)
+                sheet.write(rownum + 1, idx + 1, smart_str(e), _styles[hash(fmt)])
 
     book.save(response)
     return response

--- a/adminactions/api.py
+++ b/adminactions/api.py
@@ -279,9 +279,10 @@ def export_as_xls2(queryset, fields=None, header=None,  # noqa
                                         fieldname,
                                         usedisplay=use_display,
                                         raw_callable=False)
+                if callable(fmt):
+                    value = xlwt.Formula(fmt(value))
                 if hash(fmt) not in _styles:
                     if callable(fmt):
-                        value = xlwt.Formula(fmt(value))
                         _styles[hash(fmt)] = xlwt.easyxf(num_format_str='formula')
                     else:
                         _styles[hash(fmt)] = xlwt.easyxf(num_format_str=fmt)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -5,6 +5,7 @@ import six
 import xlrd
 import mock
 import time
+import unittest
 
 if six.PY2:
     import unicodecsv as csv
@@ -343,6 +344,7 @@ class ExportAsXlsTest(ExportMixin, SelectRowsMixin, CheckSignalsMixin, WebTest):
             self.assertEquals(sheet.cell_value(0, 1), u'Chäř')
             self.assertEquals(sheet.cell_value(1, 1), u'Pizzä ïs Gööd')
 
+    @unittest.skip("Impossible to reliably time different machine runs")
     def test_faster_export(self):
         # generate 3k users
         start = time.time()


### PR DESCRIPTION
## Reasoning

While working on streaming export response, I noticed that the xls export is noticeably slower than csv export of same data. While I did not find an easy way to implement streaming xls files, I did find a way to cut response time. It appears that reusing xls styles for given format (as opposed to creating new ones for each cell) shortens the response time by over 40%.

I arrived at figure after running multiple full tox tests (for the supported versions) and comparing the medians of a response that exports ~ 3k rows. And here comes the tricky part: how can we test this time improvement reliably?

## Tests

On my machine (Retina MBP 2013), the median response time without the fix was 7.54s, and with the fix 4.3s; moreover, with the fix it was always under 5.5s. While we cannot safely hit 5.5 always, I think using 6.5 as the number to strive to is "good enough", at least for my machine. So I've added a test that tests just that.

## Summary

I'll submit a PR, and let the test run on travis to see how it fares there. Please leave a comment if you have a better way to test timing. Alternatively, if there is no need to run this timing test, I can simply remove it.