### PR TITLE
Add AdminSite.each_context() to templates context.

### DIFF
--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -80,6 +80,7 @@ def byrows_update(modeladmin, request, queryset):  # noqa
         'opts': modeladmin.model._meta,
         'app_label': modeladmin.model._meta.app_label,
     }
+    ctx.update(modeladmin.admin_site.each_context(request))
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/export.py
+++ b/src/adminactions/export.py
@@ -119,6 +119,7 @@ def base_export(modeladmin, request, queryset, title, impl, name, template, form
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(template, RequestContext(request, ctx))
 
 
@@ -297,6 +298,7 @@ def export_as_fixture(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 
@@ -384,6 +386,7 @@ def export_delete_tree(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 

--- a/src/adminactions/graph.py
+++ b/src/adminactions/graph.py
@@ -153,6 +153,7 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
            'extra': extra,
            'as_json': json.dumps(table),
            'graph_type': graph_type}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response('adminactions/charts.html', RequestContext(request, ctx))
 
 

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -361,6 +361,7 @@ def mass_update(modeladmin, request, queryset):  # noqa
            # 'select_across': request.POST.get('select_across')=='1',
            'media': mark_safe(media),
            'selection': queryset}
+    ctx.update(modeladmin.admin_site.each_context(request))
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -182,6 +182,7 @@ def merge(modeladmin, request, queryset):  # noqa
                 'title': u"Merge %s" % smart_text(modeladmin.opts.verbose_name_plural),
                 'master': master,
                 'other': other})
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#django.contrib.admin.AdminSite.each_context

Specifically, I needed to change the admin site_header and site_title variables and have it display correctly on the different admin actions page. 