### PR TITLE
Add AdminSite.each_context() variables to templates context + "normalize" action display name across interface

### DIFF
--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -75,7 +75,11 @@ def byrows_update(modeladmin, request, queryset):  # noqa
     ctx = {
         'adminform': adminform,
         'actionform': actionform,
-        'title': u"By rows update %s" % smart_text(modeladmin.opts.verbose_name_plural),
+        'action_short_description': byrows_update.short_description,
+        'title': u"%s (%s)" % (
+            byrows_update.short_description.capitalize(),
+            smart_text(modeladmin.opts.verbose_name_plural),
+        ),
         'formset': formset,
         'opts': modeladmin.model._meta,
         'app_label': modeladmin.model._meta.app_label,
@@ -88,7 +92,7 @@ def byrows_update(modeladmin, request, queryset):  # noqa
     return render_to_response(tpl, RequestContext(request, ctx))
 
 
-byrows_update.short_description = "By rows update"
+byrows_update.short_description = _("By rows update")
 
 
 def byrows_update_get_fields(modeladmin):

--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -80,7 +80,10 @@ def byrows_update(modeladmin, request, queryset):  # noqa
         'opts': modeladmin.model._meta,
         'app_label': modeladmin.model._meta.app_label,
     }
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -80,6 +80,7 @@ def byrows_update(modeladmin, request, queryset):  # noqa
         'opts': modeladmin.model._meta,
         'app_label': modeladmin.model._meta.app_label,
     }
+    ctx.update(modeladmin.admin_site.each_context(request))
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/export.py
+++ b/src/adminactions/export.py
@@ -37,7 +37,7 @@ def get_action(request):
     return request.POST.getlist('action')[action_index]
 
 
-def base_export(modeladmin, request, queryset, title, impl, name, template, form_class, ):
+def base_export(modeladmin, request, queryset, title, impl, name, action_short_description, template, form_class, ):
     """
         export a queryset to csv file
     """
@@ -110,6 +110,7 @@ def base_export(modeladmin, request, queryset, title, impl, name, template, form
     # tpl = 'adminactions/export_csv.html'
     ctx = {'adminform': adminForm,
            'change': True,
+           'action_short_description': action_short_description,
            'title': title,
            'is_popup': False,
            'save_as': False,
@@ -131,7 +132,11 @@ def export_as_csv(modeladmin, request, queryset):
     return base_export(modeladmin, request, queryset,
                        impl=_export_as_csv,
                        name='export_as_csv',
-                       title=_('Export as CSV'),
+                       action_short_description=export_as_csv.short_description,
+                       title=u"%s (%s)" % (
+                           export_as_csv.short_description.capitalize(),
+                           modeladmin.opts.verbose_name_plural,
+                       ),
                        template='adminactions/export_csv.html',
                        form_class=CSVOptions)
 
@@ -143,7 +148,11 @@ def export_as_xls(modeladmin, request, queryset):
     return base_export(modeladmin, request, queryset,
                        impl=_export_as_xls,
                        name='export_as_xls',
-                       title=_('Export as XLS'),
+                       action_short_description=export_as_xls.short_description,
+                       title=u"%s (%s)" % (
+                           export_as_xls.short_description.capitalize(),
+                           modeladmin.opts.verbose_name_plural,
+                       ),
                        template='adminactions/export_xls.html',
                        form_class=XLSOptions)
 
@@ -292,7 +301,11 @@ def export_as_fixture(modeladmin, request, queryset):
     tpl = 'adminactions/export_fixture.html'
     ctx = {'adminform': adminForm,
            'change': True,
-           'title': _('Export as Fixture'),
+           'action_short_description': export_as_fixture.short_description,
+           'title': "%s (%s)" % (
+               export_as_fixture.short_description.capitalize(),
+               modeladmin.opts.verbose_name_plural,
+            ),
            'is_popup': False,
            'save_as': False,
            'has_delete_permission': False,
@@ -383,7 +396,11 @@ def export_delete_tree(modeladmin, request, queryset):
     tpl = 'adminactions/export_fixture.html'
     ctx = {'adminform': adminForm,
            'change': True,
-           'title': _('Export Delete Tree'),
+           'action_short_description': export_delete_tree.short_description,
+           'title': u"%s (%s)" % (
+                export_delete_tree.short_description.capitalize(),
+                modeladmin.opts.verbose_name_plural,
+            ),
            'is_popup': False,
            'save_as': False,
            'has_delete_permission': False,

--- a/src/adminactions/export.py
+++ b/src/adminactions/export.py
@@ -119,6 +119,7 @@ def base_export(modeladmin, request, queryset, title, impl, name, template, form
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(template, RequestContext(request, ctx))
 
 
@@ -297,6 +298,7 @@ def export_as_fixture(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 
@@ -384,6 +386,7 @@ def export_delete_tree(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 

--- a/src/adminactions/export.py
+++ b/src/adminactions/export.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from itertools import chain
 from six.moves import zip
 
+import django
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -119,7 +120,10 @@ def base_export(modeladmin, request, queryset, title, impl, name, template, form
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
     return render_to_response(template, RequestContext(request, ctx))
 
 
@@ -298,7 +302,10 @@ def export_as_fixture(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
     return render_to_response(tpl, RequestContext(request, ctx))
 
 
@@ -386,7 +393,10 @@ def export_delete_tree(modeladmin, request, queryset):
            'opts': queryset.model._meta,
            'app_label': queryset.model._meta.app_label,
            'media': mark_safe(media)}
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
     return render_to_response(tpl, RequestContext(request, ctx))
 
 

--- a/src/adminactions/graph.py
+++ b/src/adminactions/graph.py
@@ -148,7 +148,11 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
     ctx = {'adminform': adminForm,
            'action': 'graph_queryset',
            'opts': modeladmin.model._meta,
-           'title': u"Graph %s" % smart_text(modeladmin.opts.verbose_name_plural),
+           'action_short_description': graph_queryset.short_description,
+           'title': u"%s (%s)" % (
+                graph_queryset.short_description.capitalize(),
+                smart_text(modeladmin.opts.verbose_name_plural),
+            ),
            'app_label': queryset.model._meta.app_label,
            'media': media,
            'extra': extra,
@@ -161,4 +165,4 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
     return render_to_response('adminactions/charts.html', RequestContext(request, ctx))
 
 
-graph_queryset.short_description = "Graph selected records"
+graph_queryset.short_description = _("Graph selected records")

--- a/src/adminactions/graph.py
+++ b/src/adminactions/graph.py
@@ -153,6 +153,7 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
            'extra': extra,
            'as_json': json.dumps(table),
            'graph_type': graph_type}
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response('adminactions/charts.html', RequestContext(request, ctx))
 
 

--- a/src/adminactions/graph.py
+++ b/src/adminactions/graph.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+import django
 from django.views.decorators.csrf import csrf_exempt
 from six.moves import zip
 
@@ -153,7 +154,10 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
            'extra': extra,
            'as_json': json.dumps(table),
            'graph_type': graph_type}
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
     return render_to_response('adminactions/charts.html', RequestContext(request, ctx))
 
 

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -346,7 +346,11 @@ def mass_update(modeladmin, request, queryset):  # noqa
     tpl = 'adminactions/mass_update.html'
     ctx = {'adminform': adminForm,
            'form': form,
-           'title': u"Mass update %s" % smart_text(modeladmin.opts.verbose_name_plural),
+           'action_short_description': mass_update.short_description,
+           'title': u"%s (%s)" % (
+               mass_update.short_description.capitalize(),
+               smart_text(modeladmin.opts.verbose_name_plural),
+            ),
            'grouped': grouped,
            'fieldvalues': json.dumps(grouped, default=dthandler),
            'change': True,
@@ -370,4 +374,4 @@ def mass_update(modeladmin, request, queryset):  # noqa
     return render_to_response(tpl, RequestContext(request, ctx))
 
 
-mass_update.short_description = "Mass update"
+mass_update.short_description = _("Mass update")

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -12,6 +12,7 @@ import six
 # else:
 from collections import OrderedDict as SortedDict, defaultdict
 
+import django
 from django import forms
 from django.contrib import messages
 from django.contrib.admin import helpers
@@ -361,7 +362,10 @@ def mass_update(modeladmin, request, queryset):  # noqa
            # 'select_across': request.POST.get('select_across')=='1',
            'media': mark_safe(media),
            'selection': queryset}
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -361,6 +361,7 @@ def mass_update(modeladmin, request, queryset):  # noqa
            # 'select_across': request.POST.get('select_across')=='1',
            'media': mark_safe(media),
            'selection': queryset}
+    ctx.update(modeladmin.admin_site.each_context(request))
 
     return render_to_response(tpl, RequestContext(request, ctx))
 

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from datetime import datetime
 
+import django
 from django import forms
 from django.contrib import messages
 from django.contrib.admin import helpers
@@ -182,7 +183,10 @@ def merge(modeladmin, request, queryset):  # noqa
                 'title': u"Merge %s" % smart_text(modeladmin.opts.verbose_name_plural),
                 'master': master,
                 'other': other})
-    ctx.update(modeladmin.admin_site.each_context(request))
+    if django.VERSION[:2] > (1, 7):
+        ctx.update(modeladmin.admin_site.each_context(request))
+    else:
+        ctx.update(modeladmin.admin_site.each_context())
     return render_to_response(tpl, RequestContext(request, ctx))
 
 

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -182,6 +182,7 @@ def merge(modeladmin, request, queryset):  # noqa
                 'title': u"Merge %s" % smart_text(modeladmin.opts.verbose_name_plural),
                 'master': master,
                 'other': other})
+    ctx.update(modeladmin.admin_site.each_context(request))
     return render_to_response(tpl, RequestContext(request, ctx))
 
 

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -180,7 +180,11 @@ def merge(modeladmin, request, queryset):  # noqa
     ctx.update({'adminform': adminForm,
                 'formset': formset,
                 'media': mark_safe(media),
-                'title': u"Merge %s" % smart_text(modeladmin.opts.verbose_name_plural),
+                'action_short_description': merge.short_description,
+                'title': u"%s (%s)" % (
+                    merge.short_description.capitalize(),
+                    smart_text(modeladmin.opts.verbose_name_plural),
+                ),
                 'master': master,
                 'other': other})
     if django.VERSION[:2] > (1, 7):

--- a/src/adminactions/templates/adminactions/byrows_update.html
+++ b/src/adminactions/templates/adminactions/byrows_update.html
@@ -41,7 +41,7 @@
                 <thead>
                     <tr>
                         {% for field in form.visible_fields %}
-                        <th>{{ field.label|capfirst }}</th>
+                        <th><label class="{% if field.field.required %}required{% endif %}">{{ field.label|capfirst }}</label></th>
                         {% endfor %}
                     </tr>
                 </thead>

--- a/src/adminactions/templates/adminactions/byrows_update.html
+++ b/src/adminactions/templates/adminactions/byrows_update.html
@@ -20,7 +20,7 @@
         <a href="../../">{% trans "Home" %}</a> &rsaquo;
         <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo;
         <a href=".">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-        By row update
+        {{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 

--- a/src/adminactions/templates/adminactions/charts.html
+++ b/src/adminactions/templates/adminactions/charts.html
@@ -18,7 +18,7 @@
         <a href="../../">{% trans "Home" %}</a> &rsaquo;
         <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo;
         <a href=".">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-        Graph
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}
 {% endblock %}

--- a/src/adminactions/templates/adminactions/export_csv.html
+++ b/src/adminactions/templates/adminactions/export_csv.html
@@ -47,7 +47,7 @@
         <a href="{% url 'admin:index' %}{{ app_label}}">{{ app_label|capfirst }}</a> &rsaquo;
         {% if has_change_permission %}<a
                 href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %} &rsaquo;
-        {% trans "CSV Export Options" %}
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 

--- a/src/adminactions/templates/adminactions/export_fixture.html
+++ b/src/adminactions/templates/adminactions/export_fixture.html
@@ -6,7 +6,7 @@
         <a href="../../">{% trans "Home" %}</a> &rsaquo;
         <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo;
         <a href=".">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-        Fixture Export Options
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 

--- a/src/adminactions/templates/adminactions/export_xls.html
+++ b/src/adminactions/templates/adminactions/export_xls.html
@@ -20,7 +20,7 @@
         <a href="{% url 'admin:index' %}{{ app_label}}">{{ app_label|capfirst }}</a> &rsaquo;
         {% if has_change_permission %}<a
                 href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %} &rsaquo;
-        {% trans "XLS Export Options" %}
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 

--- a/src/adminactions/templates/adminactions/mass_update.html
+++ b/src/adminactions/templates/adminactions/mass_update.html
@@ -26,7 +26,7 @@
         <a href="../../">{% trans "Home" %}</a> &rsaquo;
         <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo;
         <a href=".">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-        Mass Update
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 

--- a/src/adminactions/templates/adminactions/merge.html
+++ b/src/adminactions/templates/adminactions/merge.html
@@ -5,7 +5,7 @@
         <a href="../../">{% trans "Home" %}</a> &rsaquo;
         <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo;
         <a href=".">{{ opts.verbose_name_plural|capfirst }}</a> &rsaquo;
-        {% trans "Merge records" %}
+	{{ action_short_description|capfirst }}
     </div>
 {% endif %}{% endblock %}
 {% block content %}


### PR DESCRIPTION
## Add AdminSite.each_context() variables to templates context.

See https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#django.contrib.admin.AdminSite.each_context

For example, it allow to  change the admin site_header and site_title variables and have it display correctly on the different admin actions pages.

## "Normalize" action display name across interface
That is, use the same pattern to display the action name on the different pages and use the action short_description variable.  