### PR TITLE
adding add_items and remove_items to ManyToMany fields in mass_update

### DIFF
--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -52,6 +52,18 @@ change_protocol = lambda arg, value: re.sub('^[a-z]*://', "%s://" % arg, value)
 disable_if_not_nullable = lambda field: field.null
 disable_if_unique = lambda field: not field.unique
 
+def add_items(items, m2m):
+    for i in items:
+        if i not in m2m.all():
+            m2m.add(i)
+    return m2m.all()
+
+def remove_items(items, m2m):
+    for i in items:
+        if i in m2m.all():
+            m2m.remove(i)
+    return m2m.all()
+
 
 class OperationManager(object):
     """
@@ -113,7 +125,9 @@ OPERATIONS = OperationManager({
     df.EmailField: [('change domain', (change_domain, True, True, "")),
                     ('upper', (string.upper, False, True, "convert to uppercase")),
                     ('lower', (string.lower, False, True, "convert to lowercase"))],
-    df.URLField: [('change protocol', (change_protocol, True, True, ""))]
+    df.URLField: [('change protocol', (change_protocol, True, True, ""))],
+    df.related.ManyToManyField: [('add items', (add_items, True, True, "")),
+                                 ('remove items', (remove_items, True, True, ""))]
 })
 
 

--- a/src/adminactions/templates/adminactions/mass_update.html
+++ b/src/adminactions/templates/adminactions/mass_update.html
@@ -43,7 +43,7 @@
         <form action="" method="post">
             {% csrf_token %}
             <table border="1">
-                {% for field in adminform.form.configured_fields %}
+                {% for field in configured_fields %}
                     <tr>
                         <td>{{ field.label_tag }}</td>
                         <td colspan="4">
@@ -66,7 +66,7 @@
                         <small><i>(sample)</i></small>
                     </th>
                 </tr>
-                {% for field in adminform.form.model_fields %}
+                {% for field in model_fields %}
                     <tr class="{{ field.name }}-row">
                         <td>{% if field.field.required %}
                             <b>{% endif %} {{ field.label_tag }}{% if field.field.required %}</b>{% endif %}  </td>


### PR DESCRIPTION
Mass Update only allows common operation (set) in ManyToMany fields. I added methods to add or remove  items  if the relation exists.