### PR TITLE
wrap render_to_response() for older django versions

### DIFF
--- a/src/adminactions/api.py
+++ b/src/adminactions/api.py
@@ -16,7 +16,7 @@ from django.http import HttpResponse
 from django.utils import dateformat
 from django.utils.encoding import force_text, smart_str, smart_text
 from django.utils.timezone import get_default_timezone
-from adminactions import compat
+from adminactions.compat import *
 from adminactions.templatetags.actions import get_field_value
 from adminactions.utils import clone_instance, get_field_by_path
 

--- a/src/adminactions/api.py
+++ b/src/adminactions/api.py
@@ -16,7 +16,7 @@ from django.http import HttpResponse
 from django.utils import dateformat
 from django.utils.encoding import force_text, smart_str, smart_text
 from django.utils.timezone import get_default_timezone
-from adminactions.compat import *
+from adminactions import compat
 from adminactions.templatetags.actions import get_field_value
 from adminactions.utils import clone_instance, get_field_by_path
 

--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -3,11 +3,10 @@ from django.contrib import messages
 from django.contrib.admin import helpers
 from django.forms.models import modelform_factory
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template.context import RequestContext
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 
+from adminactions.compat import render
 from adminactions.forms import GenericActionForm
 from adminactions.models import get_permission_codename
 
@@ -89,7 +88,7 @@ def byrows_update(modeladmin, request, queryset):  # noqa
     else:
         ctx.update(modeladmin.admin_site.each_context())
 
-    return render_to_response(tpl, RequestContext(request, ctx))
+    return render(request, tpl, ctx)
 
 
 byrows_update.short_description = _("By rows update")

--- a/src/adminactions/compat.py
+++ b/src/adminactions/compat.py
@@ -101,11 +101,16 @@ elif version >= (1, 4):  # noqa
 
 # Django 1.10 render() vs Django < 1.10 render_to_response()
 if version < (1, 9):
-    def render(request, template_name, context=None, content_type=None,
-               status=None, using=None):
-        """A render() wrapper around render_to_response() for Django < 1.9."""
-        return render_to_response(
-            template_name, context=RequestContext(request, context),
-            content_type=content_type, status=status, using=using)
+    def render(request, template, context=None, **kwargs):
+        """A render() wrapper around render_to_response() for Django < 1.9.
+
+        There are more arguments to render() and render_to_response(),
+        and they are different across django versions.
+
+        As this wrapper is only ever used from within this package,
+        only request, template and context are handled, others are accepted
+        but will be discarded.
+        """
+        return render_to_response(template, context=RequestContext(request, context))
 else:
     from django.shortcuts import render

--- a/src/adminactions/compat.py
+++ b/src/adminactions/compat.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 
 import django
 import django.db.transaction as t
+from django.shortcuts import render_to_response
+from django.template.context import RequestContext
 
 version = django.VERSION[:2]
 
@@ -96,3 +98,14 @@ elif version >= (1, 4):  # noqa
 
     def model_has_field(model, field_name):
         return field_name in model._meta.get_all_field_names()
+
+# Django 1.10 render() vs Django < 1.10 render_to_response()
+if version < (1, 9):
+    def render(request, template_name, context=None, content_type=None,
+               status=None, using=None):
+        """A render() wrapper around render_to_response() for Django < 1.9."""
+        return render_to_response(
+            template_name, context=RequestContext(request, context),
+            content_type=content_type, status=status, using=using)
+else:
+    from django.shortcuts import render # noqa

--- a/src/adminactions/compat.py
+++ b/src/adminactions/compat.py
@@ -108,4 +108,4 @@ if version < (1, 9):
             template_name, context=RequestContext(request, context),
             content_type=content_type, status=status, using=using)
 else:
-    from django.shortcuts import render # noqa
+    from django.shortcuts import render

--- a/src/adminactions/compat.py
+++ b/src/adminactions/compat.py
@@ -111,6 +111,6 @@ if version < (1, 9):
         only request, template and context are handled, others are accepted
         but will be discarded.
         """
-        return render_to_response(template, context=RequestContext(request, context))
+        return render_to_response(template, RequestContext(request, context))
 else:
     from django.shortcuts import render

--- a/src/adminactions/compat.py
+++ b/src/adminactions/compat.py
@@ -101,15 +101,17 @@ elif version >= (1, 4):  # noqa
 
 # Django 1.10 render() vs Django < 1.10 render_to_response()
 if version < (1, 9):
-    def render(request, template, context=None, **kwargs):
+    def render(request, template, context=None):
         """A render() wrapper around render_to_response() for Django < 1.9.
 
         There are more arguments to render() and render_to_response(),
         and they are different across django versions.
 
         As this wrapper is only ever used from within this package,
-        only request, template and context are handled, others are accepted
-        but will be discarded.
+        only request, template and context are handled.
+        Other args and kwargs are not accepted and will raise an Exception,
+        which will fail louder and earlier than accepting and silently
+        discarding them.
         """
         return render_to_response(template, RequestContext(request, context))
 else:

--- a/src/adminactions/export.py
+++ b/src/adminactions/export.py
@@ -15,11 +15,10 @@ from django.db import router
 from django.db.models import ForeignKey, ManyToManyField
 from django.db.models.deletion import Collector
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template.context import RequestContext
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
+from adminactions.compat import render
 from adminactions.api import (export_as_csv as _export_as_csv,
                               export_as_xls as _export_as_xls,)
 from adminactions.exceptions import ActionInterrupted
@@ -126,7 +125,7 @@ def base_export(modeladmin, request, queryset, title, impl,  # noqa
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-    return render_to_response(template, RequestContext(request, ctx))
+    return render(request, template, ctx)
 
 
 def export_as_csv(modeladmin, request, queryset):
@@ -320,7 +319,7 @@ def export_as_fixture(modeladmin, request, queryset):
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-    return render_to_response(tpl, RequestContext(request, ctx))
+    return render(request, tpl, ctx)
 
 
 export_as_fixture.short_description = _("Export as fixture")
@@ -415,7 +414,7 @@ def export_delete_tree(modeladmin, request, queryset):  # noqa
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-    return render_to_response(tpl, RequestContext(request, ctx))
+    return render(request, tpl, ctx)
 
 
 export_delete_tree.short_description = _("Export delete tree")

--- a/src/adminactions/graph.py
+++ b/src/adminactions/graph.py
@@ -12,12 +12,10 @@ from django.db.models.fields.related import ForeignKey
 from django.forms.fields import BooleanField, CharField, ChoiceField
 from django.forms.forms import DeclarativeFieldsMetaclass, Form
 from django.forms.widgets import HiddenInput, MultipleHiddenInput
-from django.shortcuts import render_to_response
-from django.template.context import RequestContext
 from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 
-from adminactions.compat import get_field_by_name
+from adminactions.compat import get_field_by_name, render
 from adminactions.exceptions import ActionInterrupted
 from adminactions.models import get_permission_codename
 from adminactions.signals import (adminaction_end, adminaction_requested,
@@ -160,7 +158,8 @@ def graph_queryset(modeladmin, request, queryset):  # noqa
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-    return render_to_response('adminactions/charts.html', RequestContext(request, ctx))
+    tpl = 'adminactions/charts.html'
+    return render(request, tpl, ctx)
 
 
 graph_queryset.short_description = _("Graph selected records")

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -17,7 +17,6 @@ from django.forms.models import (InlineForeignKeyField,
                                  ModelMultipleChoiceField, construct_instance,
                                  modelform_factory,)
 from django.http import HttpResponseRedirect
-from django.shortcuts import render
 from django.utils.encoding import smart_text
 from django.utils.functional import curry
 from django.utils.safestring import mark_safe

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -17,15 +17,13 @@ from django.forms.models import (InlineForeignKeyField,
                                  ModelMultipleChoiceField, construct_instance,
                                  modelform_factory,)
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response, render
-from django.template.context import RequestContext
+from django.shortcuts import render
 from django.utils.encoding import smart_text
 from django.utils.functional import curry
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from adminactions import compat
-from adminactions.compat import get_field_by_name
+from adminactions.compat import get_field_by_name, render
 from adminactions.exceptions import ActionInterrupted
 from adminactions.forms import GenericActionForm
 from adminactions.models import get_permission_codename
@@ -364,11 +362,6 @@ def mass_update(modeladmin, request, queryset):  # noqa
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-
-    if django.VERSION[:2] > (1, 8):
-        return render(request, tpl, context=ctx)
-    else:
-        return render_to_response(tpl, RequestContext(request, ctx))
-
+    return render(request, tpl, ctx)
 
 mass_update.short_description = _("Mass update")

--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -22,6 +22,7 @@ from django.utils.functional import curry
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
+from adminactions import compat
 from adminactions.compat import get_field_by_name, render
 from adminactions.exceptions import ActionInterrupted
 from adminactions.forms import GenericActionForm

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -12,13 +12,11 @@ from django.forms import HiddenInput, TextInput
 from django.forms.formsets import formset_factory
 from django.forms.models import model_to_dict, modelform_factory
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response, render
-from django.template import RequestContext
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
-import adminactions.compat as transaction
+import adminactions.compat as transaction, render
 from adminactions import api
 from adminactions.forms import GenericActionForm
 from adminactions.models import get_permission_codename
@@ -191,10 +189,7 @@ def merge(modeladmin, request, queryset):  # noqa
         ctx.update(modeladmin.admin_site.each_context(request))
     else:
         ctx.update(modeladmin.admin_site.each_context())
-    if django.VERSION[:2] > (1, 8):
-        return render(request, tpl, context=ctx)
-    else:
-        return render_to_response(tpl, RequestContext(request, ctx))
 
+    return render(request, tpl, ctx)
 
 merge.short_description = _("Merge selected %(verbose_name_plural)s")

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -16,8 +16,9 @@ from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
-import adminactions.compat as transaction, render
 from adminactions import api
+import adminactions.compat as transaction
+from adminactions.compat import render
 from adminactions.forms import GenericActionForm
 from adminactions.models import get_permission_codename
 from adminactions.utils import clone_instance


### PR DESCRIPTION
fixes #103 

* wrap the old render_to_response() into a fake render() for older django versions
* let newer django versions use django.shortcuts.render()
* in action modules replace `from django.shortcuts import render_to_template` with `from adminactions.compat import render`, and let views `render()` instead `render_to_template()`
* removed now unused imports
* old django = django 1.8 and older; new django = django 1.9 and newer (1.9 does both)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saxix/django-adminactions/104)
<!-- Reviewable:end -->
