### PR TITLE
preserve query string parameters (namely filters) during merge action

### DIFF
--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -148,7 +148,7 @@ def merge(modeladmin, request, queryset):  # noqa
                 m2m = None
             fields = form.cleaned_data['field_names']
             api.merge(master, other, fields=fields, commit=True, m2m=m2m, related=related)
-            return HttpResponseRedirect(request.path)
+            return HttpResponseRedirect(request.get_full_path())
         else:
             messages.error(request, form.errors)
     else:

--- a/src/adminactions/templates/adminactions/merge_preview.html
+++ b/src/adminactions/templates/adminactions/merge_preview.html
@@ -10,7 +10,7 @@
     </div>
 {% endif %}{% endblock %}
 {% block content %}
-    <form method="post" action=".">{% csrf_token %}
+    <form method="post">{% csrf_token %}
         {% for f in adminform.form.hidden_fields %}{{ f }}{% endfor %}
         {% for f in adminform.form.action_fields %}{{ f }}{% endfor %}
     <table class="mergetable">


### PR DESCRIPTION
Filters and other query string parameters are lost during merge action. This is unpleasant and can even lead to error if the default filter queryset is overridden. This fixes that.

Note: loss of query string parameter can be issue also in other actions. But I don't use them, so I fixed only the merge action.