### PR TITLE
Add Python 3.6 check to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ elif sys.version_info[0] == 3:
     if sys.version_info[1] in [3,4]:
         from importlib.machinery import SourceFileLoader
         app = SourceFileLoader("adminactions", init).load_module()
-    elif sys.version_info[1] in [5]:
+    elif sys.version_info[1] in [5,6]:
         import importlib.util
         spec = importlib.util.spec_from_file_location("adminactions", init)
         app = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Installation was failing for Python 3.6 because Python 3.6 fell outside the `if/elif` statement where `app` is defined. This is a quick fix for that.