### PR TITLE
Avoid RemovedInDjango19Warning from massupdate

### DIFF
--- a/src/adminactions/templatetags/massupdate.py
+++ b/src/adminactions/templatetags/massupdate.py
@@ -12,9 +12,11 @@ from adminactions.compat import get_field_by_name
 from adminactions.mass_update import OPERATIONS
 
 try:
-    from django.forms.util import flatatt
-except ImportError:
+    # Import module from new Django 1.9 place first
+    # to avoid RemovedInDjango19Warning to be raised
     from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 
 
 register = Library()


### PR DESCRIPTION
Before this, a warning is always thrown for `src/adminactions/templatetags/massupdate.py` because it tries to import first the outdated module path. Only if that fails, it tries the next new one.

With this change, the code imports first from new location to then try importing from old location. That ensures old code still works and new code gets no warning.