### PR TITLE
don't use required attribute -> fix inactive merge button

### DIFF
--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -25,6 +25,8 @@ from .utils import clone_instance
 
 
 class MergeForm(GenericActionForm):
+    use_required_attribute = False
+
     DEP_MOVE = 1
     DEP_DELETE = 2
     GEN_IGNORE = 1


### PR DESCRIPTION
Since Django 1.10, required fields adds `required` attribute. It causes, that the `Preview` button does nothing, which is very confusing. If required fields are omitted, it shows standart clean errors.