### PR TITLE
merge: don't show green, if both sides are the same

### DIFF
--- a/src/adminactions/static/adminactions/js/merge.js
+++ b/src/adminactions/static/adminactions/js/merge.js
@@ -21,7 +21,9 @@
 
                 $('td', this).removeClass("selected");
 
-                if ($('input.raw-value', $result).val() === $('input.raw-value', $left).val()) {
+                if ($('input.raw-value', $right).val() === $('input.raw-value', $left).val()) {
+                    $('p.display', $result).text($('p.display', $left).text());
+                } else if ($('input.raw-value', $result).val() === $('input.raw-value', $left).val()) {
                     $(this).find('td.origin').addClass("selected");
                     $('p.display', $result).text($('p.display', $left).text());
                 } else if ($('input.raw-value', $result).val() === $('input.raw-value', $right).val()) {


### PR DESCRIPTION
In the merge action selection, if both sides are the same, the green color on one side doesn't make much sense. If the green color is showed only when there is difference, then user clearly sees on which fields he should decide which side to choose.
