### PR TITLE
ensure, that jquery is loaded before merge.min.js

### DIFF
--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -70,7 +70,11 @@ class MergeForm(GenericActionForm):
         return super(MergeForm, self).is_valid()
 
     class Media:
-        js = ['adminactions/js/merge.min.js']
+        js = [
+            'admin/js/vendor/jquery/jquery.js',
+            'admin/js/jquery.init.js',
+            'adminactions/js/merge.min.js',
+        ]
         css = {'all': ['adminactions/css/adminactions.min.css']}
 
 


### PR DESCRIPTION
Sometimes the JavaScripts are ordered in such order, that `merge.min.js` is before `jquery.init.js`. In that case the merge action doesn't work, because it has not access to JQuery at load time.

This fixes that, but I don't consider it an ideal solution, because it uses fixed JQuery path, which can interfere with changed path in settings.
Please have a look at this and try  to suggest better solutions.