### PR TITLE
Fixes for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=2.0
 
 
 matrix:

--- a/src/adminactions/api.py
+++ b/src/adminactions/api.py
@@ -21,6 +21,14 @@ from . import compat
 from .templatetags.actions import get_field_value
 from .utils import clone_instance, get_field_by_path
 
+def remote_field(field_object):
+    """ Backwards compatibility of remote_field with Django <= 1.8 """
+    if hasattr(field_object, 'remote_field'):
+        return  field_object.remote_field
+    else:  # Django <= 1.8
+        return field_object.rel
+
+
 # try:
 #     # actually supported in admin actions since django >= 1.6
 #     # (see https://code.djangoproject.com/ticket/20331),
@@ -89,7 +97,7 @@ def merge(master, other, fields=None, commit=False, m2m=None, related=None):  # 
             if getattr(field, 'many_to_many', None):
                 if isinstance(field, ManyToManyField):
                     # direct relation
-                    if not field.rel.through._meta.auto_created:
+                    if not remote_field(field).through._meta.auto_created:
                         continue
                     m2m.add(field.name)
                 else:

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -70,7 +70,11 @@ class MergeForm(GenericActionForm):
         return super(MergeForm, self).is_valid()
 
     class Media:
-        js = ['adminactions/js/merge.min.js']
+        js = [
+            'admin/js/vendor/jquery/jquery.js',
+            'admin/js/jquery.init.js',
+            'adminactions/js/merge.min.js',
+        ]
         css = {'all': ['adminactions/css/adminactions.min.css']}
 
 

--- a/src/adminactions/models.py
+++ b/src/adminactions/models.py
@@ -22,15 +22,16 @@ def get_models(app_config):
 def create_extra_permission(sender, **kwargs):
     from django.contrib.auth.models import Permission
     from django.contrib.contenttypes.models import ContentType
+    ContentType.objects.clear_cache()
 
     app_config = kwargs.get('app_config', sender)
 
     for model in get_models(app_config):
+        ct = ContentType.objects.get_for_model(model)
         for action in ('adminactions_export', 'adminactions_massupdate', 'adminactions_merge', 'adminactions_chart', 'adminactions_byrowsupdate'):
             opts = model._meta
             codename = get_permission_codename(action, opts)
             label = 'Can {} {} (adminactions)'.format(action.replace('adminactions_', ""), opts.verbose_name_raw)
-            ct = ContentType.objects.get_for_model(model)
             Permission.objects.get_or_create(codename=codename, content_type=ct, defaults={'name': label[:50]})
 
 # post_migrate = Signal(providing_args=["app_config", "verbosity", "interactive", "using"])

--- a/src/adminactions/utils.py
+++ b/src/adminactions/utils.py
@@ -9,6 +9,14 @@ from django.utils.encoding import smart_text
 from adminactions.compat import get_all_field_names, get_field_by_name
 
 
+def remote_field_model(field_object):
+    """ Backwards compatibility of remote_field.model with Django <= 1.8 """
+    if hasattr(field_object, 'remote_field'):
+        return  field_object.remote_field.model
+    else:  # Django <= 1.8
+        return field_object.rel.to
+
+
 def clone_instance(instance, fieldnames=None):
     """
         returns a copy of the passed instance.
@@ -158,7 +166,7 @@ def get_field_by_path(model, field_path):
         field_object, model, direct, m2m = get_field_by_name(model, target)
         if isinstance(field_object, models.fields.related.ForeignKey):
             if parts[1:]:
-                return get_field_by_path(field_object.rel.to, '.'.join(parts[1:]))
+                return get_field_by_path(remote_field_model(field_object), '.'.join(parts[1:]))
             else:
                 return field_object
         else:

--- a/src/requirements/testing.pip
+++ b/src/requirements/testing.pip
@@ -1,6 +1,6 @@
 check-manifest
 django-dynamic-fixture
-django-webtest==1.9.1
+django-webtest==1.9.2
 flake8
 mock>=1.0.1
 modernize

--- a/tests/demo/migrations/0001_initial.py
+++ b/tests/demo/migrations/0001_initial.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
             name='DemoOneToOne',
             fields=[
                 ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
-                ('demo', models.OneToOneField(to='demo.DemoModel', related_name='onetoone')),
+                ('demo', models.OneToOneField(to='demo.DemoModel', related_name='onetoone', on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/tests/demo/settings.py
+++ b/tests/demo/settings.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import os
 
+import django
+
 here = os.path.dirname(__file__)
 # sys.path.append(os.path.abspath(os.path.join(here, os.pardir)))
 # sys.path.append(os.path.abspath(os.path.join(here, os.pardir, 'demo')))
@@ -78,12 +80,17 @@ MEDIA_URL = ''
 STATIC_ROOT = os.path.join(here, 'static')
 STATIC_URL = '/static/'
 SECRET_KEY = 'c73*n!y=)tziu^2)y*@5i2^)$8z$tx#b9*_r3i6o1ohxo%*2^a'
-MIDDLEWARE_CLASSES = (
+MIDDLEWARES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',)
+print(django.VERSION)
+if django.VERSION >= (1, 10):
+    MIDDLEWARE =  MIDDLEWARES
+else:
+    MIDDLEWARE_CLASSES = MIDDLEWARES
 
 # MIDDLEWARE_CLASSES = [
 #     'django.middleware.security.SecurityMiddleware',

--- a/tests/demo/urls.py
+++ b/tests/demo/urls.py
@@ -10,7 +10,7 @@ admin.autodiscover()
 actions.add_to_site(admin.site)
 
 urlpatterns = (
-    url(r'admin/', include(admin.site.urls)),
+    url(r'admin/', admin.site.urls),
     url(r'as/', include(adminactions.urls)),
-    url(r'', include(admin.site.urls)),
+    url(r'', admin.site.urls),
 )

--- a/tests/test_byrows_update.py
+++ b/tests/test_byrows_update.py
@@ -3,7 +3,10 @@ import six
 from django.contrib.admin.options import ModelAdmin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
 from django_dynamic_fixture import G
 from django_webtest import WebTestMixin

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,7 +5,10 @@ from six.moves import range
 import django
 import pytest
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django_dynamic_fixture import G
 from django_webtest import WebTest
 from utils import CheckSignalsMixin, SelectRowsMixin, user_grant_permission

--- a/tests/test_mass_update.py
+++ b/tests/test_mass_update.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 import six
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
 from django_dynamic_fixture import G
 from django_webtest import WebTestMixin

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -8,7 +8,10 @@ from six.moves import range
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import Group, Permission, User
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
 from django_dynamic_fixture import G
 from django_webtest import WebTestMixin

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,7 +5,10 @@ import logging
 
 import pytest
 from django.contrib.auth.models import Permission
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from utils import user_grant_permission
 
 logger = logging.getLogger(__name__)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 import datetime
 
 import pytest
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 2.0
+    from django.core.urlresolvers import reverse
 from django.utils import dateformat
 from django.utils.encoding import smart_text
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -237,7 +237,14 @@ class DataFixtureClass(RandomDataFixture):  # it can inherit of SequentialDataFi
 
 TEST_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__),
                                   os.pardir, 'tests', 'templates')
-SETTINGS = {'MIDDLEWARE_CLASSES': global_settings.MIDDLEWARE_CLASSES,
+
+try:
+    MIDDLEWARE = global_settings.MIDDLEWARE
+except AttributeError:  # Django < 2.0
+    MIDDLEWARE = global_settings.MIDDLEWARE_CLASSES
+SETTINGS = {
+            'MIDDLEWARE_CLASSES': MIDDLEWARE,
+            'MIDDLEWARE': MIDDLEWARE,
             'TEMPLATE_DIRS': [TEST_TEMPLATES_DIR],
             'AUTHENTICATION_BACKENDS': ('django.contrib.auth.backends.ModelBackend',),
             'TEMPLATE_LOADERS': ('django.template.loaders.filesystem.Loader',

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = d{18}-py{27,34,35,36,py}
           d{19,110}-py{27,34,35,36,py}
           d{111}-py{27,34,35,36,py}
+          d{20}-py{34,35,36,py}
 
 skip_missing_interpreters = true
 
@@ -37,9 +38,9 @@ deps=
     d19: django>=1.9,<1.10
     d110: django>=1.10,<1.11
     d111: django>=1.11,<1.12
+    d20: django>=2.0,<2.11
 
     ; only for local development
-    d20: django>=2.0dev,<2.11
     dev: git+https://github.com/django/django.git
 
 


### PR DESCRIPTION
This fixes the problem with `.rel` in Django 2.0.
It also fixes all tests and the problem with content types foreign key during testing.