### PR TITLE
fix a crash with Django model choices

### DIFF
--- a/src/adminactions/templatetags/massupdate.py
+++ b/src/adminactions/templatetags/massupdate.py
@@ -39,7 +39,7 @@ def link_fields_values(d, field_name):
     for el in d.get(field_name, []):
         try:
             value, label = el
-        except TypeError:
+        except (TypeError, ValueError):
             value, label = el, el
 
         if label == '':  # ignore empty


### PR DESCRIPTION
Trying to split a string (like the key in choices) raises a `ValueError` instead of `TypeError`.