### PR TITLE
By rows bug fix and performance + usability fix

### DIFF
--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -37,11 +37,17 @@ def byrows_update(modeladmin, request, queryset):  # noqa
 
     fields = byrows_update_get_fields(modeladmin)
 
-    ActionForm = modelform_factory(modeladmin.model,
-                                   form=GenericActionForm,
-                                   fields=fields)
+    def formfield_callback(field, **kwargs):
+        return modeladmin.formfield_for_dbfield(field, request=request, **kwargs)
+    ActionForm = modelform_factory(
+        modeladmin.model,
+        form=GenericActionForm,
+        fields=fields,
+        formfield_callback=formfield_callback)
 
-    MFormSet = modelformset_factory(modeladmin.model, form=modelform, fields=fields, extra=0)
+    MFormSet = modelformset_factory(modeladmin.model, form=modelform,
+                                    fields=fields, extra=0,
+                                    formfield_callback=formfield_callback)
 
     if 'apply' in request.POST:
         actionform = ActionForm(request.POST)

--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -29,7 +29,7 @@ def byrows_update(modeladmin, request, queryset):  # noqa
         def __init__(self, *args, **kwargs):
             super(modeladmin.form, self).__init__(*args, **kwargs)
             if self.instance:
-                readonly_fields = (modeladmin.model._meta.pk.name,) + modeladmin.get_readonly_fields(request)
+                readonly_fields = (modeladmin.model._meta.pk.name,) + tuple(modeladmin.get_readonly_fields(request))
                 for fname in readonly_fields:
                     if fname in self.fields:
                         self.fields[fname].widget.attrs['readonly'] = 'readonly'

--- a/tests/test_byrows_update.py
+++ b/tests/test_byrows_update.py
@@ -78,7 +78,15 @@ class TestByRowsUpdateAction(WebTestMixin, SelectRowsMixin, TestCase):
             byrows_update_get_fields(ModelAdmin(DemoModel, self.site))
             for r, value in enumerate(self._selected_values):
                 for fname in byrows_update_get_fields(ModelAdmin(DemoModel, self.site)):
-                    assert res.form["form-%d-%s" % (r, fname)]
+                    fname = 'form-%d-%s' % (r, fname)
+
+                    try:
+                        # Attempt split (admin datetime widget) fields first
+                        assert res.form[fname + '_0']
+                    except AssertionError:
+                        # assert for non-split fields to return the regular
+                        # field name upon errors
+                        assert res.form[fname]
 
     def test_form_rows_edit(self):
         """


### PR DESCRIPTION
This fix includes #158 as well so it's actually slightly smaller.

The fix is similar, there was a bug with the `readonly_fields` that are assumed to be tuples in all cases.

And instead of loading all foreign key items it uses the same fields as the regular model admin would so it doesn't kill your system when running it on a big database.