### PR TITLE
docs: Fix simple typo, succesive -> successive

### DIFF
--- a/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js
+++ b/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js
@@ -59,7 +59,7 @@
         this.barWidth = null;
         // prop: shadowOffset
         // offset of the shadow from the slice and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowDepth
         // number of strokes to apply to the shadow, 

--- a/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js
+++ b/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js
@@ -92,7 +92,7 @@
         this.fill = true;
         // prop: shadowOffset
         // offset of the shadow from the slice and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowAlpha
         // transparency of the shadow (0 = transparent, 1 = opaque)


### PR DESCRIPTION
There is a small typo in src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js, src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js.

Should read `successive` rather than `succesive`.

