### PR TITLE
allow use ignore_fields to avoid unauthorized merge/update

### DIFF
--- a/src/adminactions/byrows_update.py
+++ b/src/adminactions/byrows_update.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext as _
 
 from .forms import GenericActionForm
 from .models import get_permission_codename
-
+from .utils import get_ignored_fields
 
 def byrows_update(modeladmin, request, queryset):  # noqa
     """
@@ -98,8 +98,9 @@ def byrows_update_get_fields(modeladmin):
         - adminactions_byrows_update_fields
         - adminactions_byrows_update_exclude
     """
+    ignored_fields = get_ignored_fields(modeladmin.model, "UPDATE_ACTION_IGNORED_FIELDS")
     out = getattr(modeladmin, 'adminactions_byrows_update_fields',
-                  [f.name for f in modeladmin.model._meta.fields if f.editable])
+                  [f.name for f in modeladmin.model._meta.fields if f.editable and f.name not in ignored_fields])
     if hasattr(modeladmin, 'adminactions_byrows_update_exclude'):
         fields = modeladmin.adminactions_byrows_update_exclude
         out = [fname for fname in fields if fname not in modeladmin.adminactions_byrows_update_exclude]

--- a/src/adminactions/forms.py
+++ b/src/adminactions/forms.py
@@ -6,6 +6,7 @@ from django.utils import formats
 from django.utils.translation import gettext_lazy as _
 
 from .api import csv, delimiters, quotes
+from .utils import get_ignored_fields
 
 
 class GenericActionForm(ModelForm):
@@ -19,10 +20,11 @@ class GenericActionForm(ModelForm):
 
     def model_fields(self):
         """
-        Returns a list of BoundField objects that aren't "private" fields.
+        Returns a list of BoundField objects that aren't "private" fields or are not ignored.
         """
+        ignored_fields = get_ignored_fields(self._meta.model, "UPDATE_ACTION_IGNORED_FIELDS")
         return [field for field in self if
-                not (field.name.startswith('_') or field.name in ['select_across', 'action'])]
+                not (field.name.startswith('_') or field.name in ['select_across', 'action'] + ignored_fields)]
 
 
 class CSVOptions(forms.Form):

--- a/src/adminactions/merge.py
+++ b/src/adminactions/merge.py
@@ -17,7 +17,7 @@ from django.utils.translation import gettext as _
 from . import api, compat as transaction
 from .forms import GenericActionForm
 from .models import get_permission_codename
-from .utils import clone_instance
+from .utils import clone_instance, get_ignored_fields
 
 
 class MergeFormBase(forms.Form):
@@ -130,16 +130,17 @@ def merge(modeladmin, request, queryset):  # noqa
 
     tpl = 'adminactions/merge.html'
     # transaction_supported = model_supports_transactions(modeladmin.model)
+    ignored_fields = get_ignored_fields(queryset.model, "MERGE_ACTION_IGNORED_FIELDS")
+
     ctx = {
         '_selected_action': request.POST.getlist(helpers.ACTION_CHECKBOX_NAME),
         'transaction_supported': 'Un',
         'select_across': request.POST.get('select_across') == '1',
         'action': request.POST.get('action'),
-        'fields': [f for f in queryset.model._meta.fields if not f.primary_key and f.editable],
+        'fields': [f for f in queryset.model._meta.fields if not f.primary_key and f.editable and f.name not in ignored_fields],
         'app_label': queryset.model._meta.app_label,
         'result': '',
         'opts': queryset.model._meta}
-
     if 'preview' in request.POST:
         master = queryset.get(pk=request.POST.get('master_pk'))
         original = clone_instance(master)

--- a/src/adminactions/utils.py
+++ b/src/adminactions/utils.py
@@ -1,8 +1,22 @@
+from django.conf import settings
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils.encoding import smart_str
 
 from adminactions.compat import get_all_field_names, get_field_by_name
+
+
+def get_ignored_fields(model, setting_var_name):
+    """
+    returns list of ignored fields which must not be modified
+    """
+    ignored_setting = getattr(settings, setting_var_name, {})
+    ignored_app = ignored_setting.get(model._meta.app_label, {})
+    if ignored_app:
+        ignored_fields = ignored_app.get(model._meta.model_name, [])
+    else:
+        ignored_fields = []
+    return ignored_fields
 
 
 def clone_instance(instance, fieldnames=None):


### PR DESCRIPTION
Hi,
i needed to ignore some fields from update/merging to avoid some security issue and i did this change.
With this setting variable we are able to ignore fields from mass update / per row update:

```
UPDATE_ACTION_IGNORED_FIELDS = {
    'app_name': {
            'user': ['is_staff', 'is_superuser'],
    },
}
```

and also with this variable we are able to ignore merging => and all ignored fields are set to default (if set).
```
MERGE_ACTION_IGNORED_FIELDS = {
    'app_name': {
            'user': ['is_staff', 'is_superuser'],
    },
}
```
