### PR TITLE
fix set if field is ManyRelatedManager

### DIFF
--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -231,7 +231,13 @@ def mass_update(modeladmin, request, queryset):  # noqa
                     old_value = getattr(record, field_name)
                     setattr(record, field_name, value_or_func(old_value))
                 else:
-                    setattr(record, field_name, value_or_func)
+                    changed_attr = getattr(record, field_name, None)
+
+                    if changed_attr.__class__.__name__ == 'ManyRelatedManager':
+                            changed_attr.set(value_or_func)
+                    else:
+                        setattr(record, field_name, value_or_func)
+
             if clean:
                 record.clean()
             record.save()


### PR DESCRIPTION
If field type is ManyRelatedManager, default function "set" throw error 500
"Direct assignment to the forward side of a many-to-many set is prohibited. Use category.set() instead."

I don't know if it is best way to fix it like my pull request.
Thanks.