### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/adminactions/mass_update.py
+++ b/src/adminactions/mass_update.py
@@ -307,7 +307,7 @@ def mass_update(modeladmin, request, queryset):  # noqa
                 filters = {"%s__in" % f.remote_field.name: queryset}
                 # Order by random to get a nice sample
                 query = f.related_model.objects.filter(**filters).distinct().order_by('?')
-                # Limit the amount of results so we don't accidently query
+                # Limit the amount of results so we don't accidentally query
                 # many thousands of items and kill the database.
                 grouped[f.name] = [(a.pk, str(a)) for a in query[:10]]
             elif hasattr(f, 'flatchoices') and f.flatchoices:

--- a/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js
+++ b/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js
@@ -148,7 +148,7 @@
             this._stackAxis = 'x';
             this.fillAxis = 'x';
         }
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         // total number of values for all bar series, total number of bar series, and position of this series
         this._plotSeriesInfo = null;

--- a/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.categoryAxisRenderer.js
+++ b/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.categoryAxisRenderer.js
@@ -221,7 +221,7 @@
             // keep a reference to these tick labels to use for redrawing plot (see bug #57)
             this.ticks = labels;
             
-            // now bin the data values to the right lables.
+            // now bin the data values to the right labels.
             for (var i=0; i<this._series.length; i++) {
                 var s = this._series[i];
                 for (var j=0; j<s.data.length; j++) {

--- a/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js
+++ b/src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js
@@ -165,7 +165,7 @@
         this._radius = null;
         // array of [start,end] angles arrays, one for each slice.  In radians.
         this._sliceAngles = [];
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         
         // set highlight colors if none provided
@@ -519,7 +519,7 @@
         // I don't think I'm going to need _dataBounds here.
         // have to go Axis scaling in a way to fit chart onto plot area
         // and provide u2p and p2u functionality for mouse cursor, etc.
-        // for convienence set _dataBounds to 0 and 100 and
+        // for convenience set _dataBounds to 0 and 100 and
         // set min/max to 0 and 100.
         this._dataBounds = {min:0, max:100};
         this.min = 0;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     # import warnings
-    # enable this to removee deprecations
+    # enable this to remove deprecations
     # warnings.simplefilter('once', DeprecationWarning)
 
     if config.option.markexpr.find("selenium") < 0 and \


### PR DESCRIPTION
There are small typos in:
- src/adminactions/mass_update.py
- src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.barRenderer.js
- src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.categoryAxisRenderer.js
- src/adminactions/static/adminactions/js/jqplot/plugins/jqplot.pieRenderer.js
- tests/conftest.py

Fixes:
- Should read `currently` rather than `currenty`.
- Should read `remove` rather than `removee`.
- Should read `labels` rather than `lables`.
- Should read `convenience` rather than `convienence`.
- Should read `accidentally` rather than `accidently`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md